### PR TITLE
#157972961 Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ docs/_build/
 target/
 
 # IDE
+.vscode
 .idea/
 
 # External Libraries 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-debug-toolbar==1.9.1
 django-filter==1.1.0
 django-formtools==1.0
 django-mobile==0.7.0
-django-recaptcha==1.4.0
+django-recaptcha==1.3.1
 django-sortedm2m==1.5.0
 django-tastypie==0.14.1
 djangorestframework==3.2.5

--- a/wger/core/tests/test_feedback.py
+++ b/wger/core/tests/test_feedback.py
@@ -75,6 +75,4 @@ class FeedbackTestCase(WorkoutManagerTestCase):
         '''
         Tests the feedback form as a logged out user
         '''
-
-        # TODO Fix this failing test
-        # self.send_feedback(logged_in=False)
+        self.send_feedback(logged_in=False)

--- a/wger/core/tests/test_registration.py
+++ b/wger/core/tests/test_registration.py
@@ -34,14 +34,13 @@ class RegistrationTestCase(WorkoutManagerTestCase):
         Tests that the correct form is used depending on global
         configuration settings
         '''
-        # TODO Fix this failing test
-        # with self.settings(WGER_SETTINGS={'USE_RECAPTCHA': True,
-        #                                   'REMOVE_WHITESPACE': False,
-        #                                   'ALLOW_REGISTRATION': True,
-        #                                   'ALLOW_GUEST_USERS': True,
-        #                                   'TWITTER': False}):
-        #     response = self.client.get(reverse('core:user:registration'))
-        #     self.assertIsInstance(response.context['form'], RegistrationForm)
+        with self.settings(WGER_SETTINGS={'USE_RECAPTCHA': True,
+                                          'REMOVE_WHITESPACE': False,
+                                          'ALLOW_REGISTRATION': True,
+                                          'ALLOW_GUEST_USERS': True,
+                                          'TWITTER': False}):
+            response = self.client.get(reverse('core:user:registration'))
+            self.assertIsInstance(response.context['form'], RegistrationForm)
 
         with self.settings(WGER_SETTINGS={'USE_RECAPTCHA': False,
                                           'REMOVE_WHITESPACE': False,

--- a/wger/utils/tests/test_middleware.py
+++ b/wger/utils/tests/test_middleware.py
@@ -36,9 +36,8 @@ class RobotsExclusionMiddlewareTestCase(WorkoutManagerTestCase):
         response = self.client.get(reverse('manager:schedule:overview'))
         self.assertFalse(response.get('X-Robots-Tag'))
 
-        # TODO Fix this failing test
-        # response = self.client.get(reverse('core:feedback'))
-        # self.assertFalse(response.get('X-Robots-Tag'))
+        response = self.client.get(reverse('core:feedback'))
+        self.assertFalse(response.get('X-Robots-Tag'))
 
         response = self.client.get(reverse('core:about'))
         self.assertFalse(response.get('X-Robots-Tag'))


### PR DESCRIPTION
#### What does this PR do?
Fix Wger's failing tests based on Django-recaptcha.

#### Description of Task to be completed?
Downgrade Django-recapture from version 1.4.0 to 1.3.1,
which is compatible with the Django version and allows failing tests to pass.

![image](https://user-images.githubusercontent.com/35847046/40769608-1acf971e-64c1-11e8-97fb-94ecd68cdd38.png)


#### How should this be manually tested?
Run `pip install -r requirements.txt`
Run `./manage.py test`

#### Any background context you want to provide?
Some tests were failing due to incompatibilty between the Django and Django-recaptcha versions.

#### What are the relevant pivotal tracker stories?
[#157972961](https://www.pivotaltracker.com/story/show/157972961)