### PR TITLE
#157731577 Add JSON export for a workout

### DIFF
--- a/wger/core/static/js/wger-core.js
+++ b/wger/core/static/js/wger-core.js
@@ -666,6 +666,28 @@ $(document).ready(function () {
     window.location.href = targetUrl;
   });
 
+  $('#download-json-link').click(function (e) {
+    var targetUrl;
+    var token;
+    var uid;
+    var workoutId;
+    var downloadInfo;
+    e.preventDefault();
+
+    downloadInfo = $('#pdf-download-info');
+
+    workoutId = downloadInfo.data('workoutId');
+    uid = downloadInfo.data('uid');
+    token = downloadInfo.data('token');
+
+    // Put together and redirect
+    targetUrl = '/' + getCurrentLanguage() +
+      '/workout/' + workoutId + '/json' +
+      '/' + uid +
+      '/' + token;
+    window.location.href = targetUrl;
+  });
+
   // Handle the workout PDF download options for schedules
   $('#download-pdf-button-schedule').click(function (e) {
     var targetUrl;

--- a/wger/manager/templates/mobile/workout/view.html
+++ b/wger/manager/templates/mobile/workout/view.html
@@ -231,6 +231,12 @@ an appointment for each training day with the appropriate exercises.{% endblockt
             </a>
         </li>
         <li>
+            <a id="download-json-link">
+                <span class="{% fa_class 'download' %}"></span>
+                {% trans "Download as JSON" %}
+            </a>
+        </li>
+        <li>
             <a href="{% url 'manager:log:log' workout.id %}">
                <span class="{% fa_class 'line-chart' %}"></span>
                {% trans "View weight log" %}

--- a/wger/manager/templates/workout/view.html
+++ b/wger/manager/templates/workout/view.html
@@ -226,6 +226,12 @@ an appointment for each training day with the appropriate exercises.{% endblockt
             </a>
         </li>
         <li>
+            <a id="download-json-link">
+                <span class="{% fa_class 'download' %}"></span>
+                {% trans "Download as JSON" %}
+            </a>
+        </li>
+        <li>
             <a href="{% url 'manager:log:log' workout.id %}">
                <span class="{% fa_class 'line-chart' %}"></span>
                {% trans "View weight log" %}

--- a/wger/manager/tests/test_json.py
+++ b/wger/manager/tests/test_json.py
@@ -1,0 +1,73 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.utils.helpers import make_token
+
+
+class WorkoutJsonExportTestCase(WorkoutManagerTestCase):
+    '''
+    Tests exporting a workout as a Json
+    '''
+
+    def test_export_json_token(self):
+        '''
+        Function to test exporting a workout as a json using tokens
+        '''
+
+        user = User.objects.get(username='test')
+        uid, token = make_token(user)
+        response = self.client.get(reverse('manager:workout:json-data', kwargs={'id': 3,
+                                                                                'uidb64': uid,
+                                                                                'token': token}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertEqual(response['Content-Disposition'],
+                         'attachment; filename=Workout-3.json')
+
+    def test_export_json_token_wrong(self):
+        '''
+        Function to test exporting a workout as a json using a wrong token
+        '''
+
+        uid = 'AB'
+        token = 'abc-11223344556677889900'
+        response = self.client.get(reverse('manager:workout:json-data', kwargs={'id': 3,
+                                                                                'uidb64': uid,
+                                                                                'token': token}))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_export_json(self, fail=False):
+        '''
+        Function to test exporting a workout as a json
+        '''
+
+        user = User.objects.get(username='test')
+        uid, token = make_token(user)
+
+        response = self.client.get(reverse('manager:workout:json-data', kwargs={'id': 3,
+                                                                                'uidb64': uid,
+                                                                                'token': token}))
+
+        if fail:
+            self.assertIn(response.status_code, (403, 404, 302))
+        else:
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response['Content-Type'], 'application/json')
+            self.assertEqual(response['Content-Disposition'],
+                             'attachment; filename=Workout-3.json')

--- a/wger/manager/urls.py
+++ b/wger/manager/urls.py
@@ -19,6 +19,7 @@ from django.conf.urls import patterns, url, include
 from django.contrib.auth.decorators import login_required
 
 from wger.manager.views import (
+    json,
     pdf,
     schedule,
     schedule_step,
@@ -112,6 +113,9 @@ patterns_workout = [
     url(r'^(?P<day_pk>\d+)/timer$',
         workout.timer,
         name='timer'),
+    url(r'^(?P<id>\d+)/json/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})$',
+        json.workout_log,
+        name='json-data'), #JS!
 ]
 
 

--- a/wger/manager/views/json.py
+++ b/wger/manager/views/json.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+import logging
+import datetime
+import json
+
+from django.http import HttpResponse
+from django.http import HttpResponseForbidden
+from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext as _
+
+from wger.manager.models import Workout
+from wger.manager.helpers import render_workout_day
+from wger.utils.helpers import check_token
+from wger.utils.pdf import styleSheet
+from wger.utils.pdf import render_footer
+
+from reportlab.lib.pagesizes import A4, cm
+from reportlab.platypus import (
+    Paragraph,
+    SimpleDocTemplate,
+    Table,
+    Spacer
+)
+
+from reportlab.lib import colors
+
+from wger import get_version
+
+logger = logging.getLogger(__name__)
+
+
+def workout_log(request, id, images=False, comments=False, uidb64=None, token=None):
+    '''
+    Generates a PDF with the contents of the given workout
+
+    See also
+    * http://www.blog.pythonlibrary.org/2010/09/21/reportlab
+    * http://www.reportlab.com/apis/reportlab/dev/platypus.html
+    '''
+    comments = bool(int(comments))
+    images = bool(int(images))
+
+    # Load the workout
+    if uidb64 is not None and token is not None:
+        if check_token(uidb64, token):
+            workout = get_object_or_404(Workout, pk=id)
+        else:
+            return HttpResponseForbidden()
+    else:
+        if request.user.is_anonymous():
+            return HttpResponseForbidden()
+        workout = get_object_or_404(Workout, pk=id, user=request.user)
+
+    if len(workout.canonical_representation['day_list']) > 0:
+
+        exercise_set = workout.canonical_representation['day_list'][0]['set_list']
+
+        workout_details = {
+            'description': workout.canonical_representation['day_list'][0]['obj'].description,
+            'workout_days': workout.canonical_representation['day_list'][0]['days_of_week']['text']
+        }
+
+        set_list = []
+
+        for set in exercise_set:
+            set_dict = {}
+            exercise_list = []
+            holder = {}
+            set_dict['set_id'] = set['obj'].id
+
+            for item in set['exercise_list']:
+                holder['name_of_exercise'] = item['obj'].name
+                holder['setting_list'] = item['setting_list']
+                holder['comments'] = item['comment_list']
+                exercise_list.append(holder)
+
+            set_dict['exercise_list'] = exercise_list
+
+            set_list.append(set_dict)
+
+        workout_details['set_list'] = set_list
+    else:
+        workout_details = []
+
+    json_data = json.dumps(workout_details)
+
+    # Create the HttpResponse object with the appropriate PDF headers.
+    response = HttpResponse(json_data, content_type='application/json')
+
+    # Create the HttpResponse object with the appropriate PDF headers.
+    response['Content-Disposition'] = 'attachment; filename=Workout-{0}.json'.format(id)
+    response['Content-Length'] = len(response.content)
+    return response


### PR DESCRIPTION
**What does this PR do?**

Adds a provision to download a workout as a JSON file

**Description of Task to be completed?**

Before when exporting workout data there is only a provision to export as a PDF. The interface looks like what is below.

<img width="1384" alt="screen shot 2018-06-01 at 19 25 55" src="https://user-images.githubusercontent.com/17172747/40852001-b959ea36-65d1-11e8-93cb-5d2a9967bae8.png">


A new option to download json is added to the interface and it now looks like this.

<img width="1440" alt="screen shot 2018-06-01 at 19 35 23" src="https://user-images.githubusercontent.com/17172747/40852384-ff6cf03a-65d2-11e8-9549-a9318300f673.png">



**How should this be manually tested?**

Click on the Download as JSON from the options menu as illustrated in the picture above and a JSON file will be downloaded to onto your machine.

**Any background context you want to provide?**

There was no option to download a workout as a JSON file but it exists now.

**What are the relevant pivotal tracker stories?**

[#157731577](https://www.pivotaltracker.com/story/show/157731577)