### PR TITLE
#157731571 Choose exercises and ingredients language

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -38,7 +38,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
@@ -107,11 +107,40 @@ $(document).ready(function() {
 -->
 {% block sidebar %}
 <h4>{% trans "Search" %}</h4>
-    <input name="term"
-           type="search"
-           id="exercise-search"
-           class="ajax-form-element form-control"
-           placeholder="{% trans 'exercise name' %}">
+<input name="term"
+        type="search"
+        id="exercise-search"
+        class="ajax-form-element form-control"
+        placeholder="{% trans 'exercise name' %}">
+
+<br/>Display exercises in:
+<button class="btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+    --select--<span class="caret"></span>
+</button>
+<ul class="dropdown-menu" role="menu"  style="padding-left: 20px;">
+    <li>
+        <a href="{% url 'exercise:exercise:overview' %}">
+            {% trans "Default" %}
+        </a>
+    </li>
+
+    {% for short_name, full_name in languages %}
+    <li>
+        <img src="/static/images/icons/flag-{{ short_name }}.svg"
+            width="18"
+            height="11"
+            alt="{% trans full_name %}"
+            title="{% trans full_name %}"
+            style="border: 1px solid #151515;">
+
+        <span>
+            <a href="{% url 'exercise:exercise:overview' %}?language={{ short_name }}">
+                {% trans full_name %}
+            </a>
+        </span>
+    </li>
+    {% endfor %}
+</ul>
 {% endblock %}
 
 

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -59,6 +59,7 @@ from wger.utils.widgets import (
 )
 from wger.config.models import LanguageConfig
 from wger.weight.helpers import process_log_entries
+from wger.core.models import Language
 
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,15 @@ class ExerciseListView(ListView):
         Filter to only active exercises in the configured languages
         '''
         languages = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
+        language_code = self.request.GET.get('language', None)
+        language = None
+        if language_code:
+            language = Language.objects.filter(short_name=language_code).first().id
+            return Exercise.objects.accepted() \
+                .filter(language=language) \
+                .order_by('category__id') \
+                .select_related()
+
         return Exercise.objects.accepted() \
             .filter(language__in=languages) \
             .order_by('category__id') \

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -70,6 +70,35 @@
                placeholder="{% trans 'ingredient name' %}"
                style="width:100%;">
     </form>
+
+<br/>Display ingredients in:
+<button class="btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+    --select--<span class="caret"></span>
+</button>
+<ul class="dropdown-menu" role="menu"  style="padding-left: 20px;">
+    <li>
+        <a href="{% url 'nutrition:ingredient:list' %}">
+            {% trans "Default" %}
+        </a>
+    </li>
+
+    {% for short_name, full_name in languages %}
+    <li>
+        <img src="/static/images/icons/flag-{{ short_name }}.svg"
+            width="18"
+            height="11"
+            alt="{% trans full_name %}"
+            title="{% trans full_name %}"
+            style="border: 1px solid #151515;">
+
+        <span>
+            <a href="{% url 'nutrition:ingredient:list' %}?language={{ short_name }}">
+                {% trans full_name %}
+            </a>
+        </span>
+    </li>
+    {% endfor %}
+</ul>
 {% endblock %}
 
 

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -40,6 +40,7 @@ from wger.utils.generic_views import (
 from wger.utils.constants import PAGINATION_OBJECTS_PER_PAGE
 from wger.utils.language import load_language, load_ingredient_languages
 from wger.utils.cache import cache_mapper
+from wger.core.models import Language
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,13 @@ class IngredientListView(ListView):
         native language, see load_ingredient_languages)
         '''
         languages = load_ingredient_languages(self.request)
+        language_code = self.request.GET.get('language', None)
+        language = None
+        if language_code:
+            language = Language.objects.filter(short_name=language_code).first().id
+            return (Ingredient.objects.filter(language=language)
+                                      .filter(status__in=Ingredient.INGREDIENT_STATUS_OK)
+                                      .only('id', 'name'))
         return (Ingredient.objects.filter(language__in=languages)
                                   .filter(status__in=Ingredient.INGREDIENT_STATUS_OK)
                                   .only('id', 'name'))


### PR DESCRIPTION
#### What does this PR do?
Allows users to choose the language for exercises and ingredients

#### Description of Task to be completed?
Selectiion of the choice language to use to display exercises and ingredients.
<img width="1680" alt="screen shot 2018-06-08 at 18 11 49" src="https://user-images.githubusercontent.com/35847046/41165919-8d649d6a-6b47-11e8-98a1-3cf33118babd.png">
Ingredients list.

<img width="1680" alt="screen shot 2018-06-08 at 18 15 30" src="https://user-images.githubusercontent.com/35847046/41166054-002653b6-6b48-11e8-8c6b-f5f70c93e4ef.png">
Exercises list.

#### How should this be manually tested?
Visit the exercises and ingredients list pages and select the language to use to display the items.

#### Any background context you want to provide?
Previously, the user could view exercises and ingredients in their default language unless they changed the overall system language.

#### What are the relevant pivotal tracker stories?
[#157731571](https://www.pivotaltracker.com/story/show/157731571)