### PR TITLE
#157731581 Danger colour for user deactivation message

### DIFF
--- a/wger/core/templates/base.html
+++ b/wger/core/templates/base.html
@@ -49,7 +49,7 @@ browsing the site as the user "{{current_user}}", all actions are performed on h
     <div class="col-sm-8" id="main-content">
         {% if messages and not no_messages %}
             {% for message in messages %}
-                <div class="alert {% if message.tags == 'warning'%}alert-error{% elif message.tags == 'info' %}alert-info{% elif message.tags == 'success' %}alert-success{% endif %}">
+                <div class="alert {% if message.tags == 'warning'%}alert-error{% elif message.tags == 'info' %}alert-info{% elif message.tags == 'success' %}alert-success{% elif 'danger' in message.tags %}alert-danger{% endif %}">
                 <a href="#" class="close extra-bold" data-dismiss="alert">&times;</a>
                 {{message}}
                 </div>

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -336,7 +336,7 @@ class UserDeactivateView(LoginRequiredMixin,
         edit_user = get_object_or_404(User, pk=pk)
         edit_user.is_active = False
         edit_user.save()
-        messages.success(self.request, _('The user was successfully deactivated'))
+        messages.success(self.request, _('The user was successfully deactivated'), 'danger')
         return reverse('core:user:overview', kwargs=({'pk': pk}))
 
 

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -15,6 +15,17 @@
 
 {% block content %}
 
+<style>
+    .trainer
+    {
+        visibility: hidden;
+    }
+
+    tr:hover .trainer, tbody tr:hover td .trainer, ul:hover .trainer
+    {
+        visibility: visible;
+    }
+</style>
 
 <h4>{% trans "Administrators and trainers" %}</h4>
 <table class="table table-hover">
@@ -25,6 +36,7 @@
     <th>{% trans "Name" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         <th style="text-align: right;">{% trans "Roles" %}</th>
+        <th></th>
     {% endif %}
 </tr>
 </thead>
@@ -58,6 +70,40 @@
         <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
             <span class="{% fa_class 'cog' %}"></span>
         </a>
+    </td>
+
+    <td style="text-align: right;">
+        {% if current_user.perms.gym_trainer and not current_user.perms.manage_gyms and not current_user.perms.manage_gyms %}
+        <div class="btn-group trainer">
+            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+                <span class="{% fa_class 'bars' %}"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu">
+                {% if current_user.obj.is_active %}
+                <li>
+                    <a href="{% url 'core:user:deactivate' current_user.obj.pk %}">
+                        <span class="{% fa_class 'exclamation-triangle' %} "></span>
+                        {% trans 'Deactivate' %}
+                    </a>
+                </li>
+                {% else %}
+                <li>
+                    <a href="{% url 'core:user:activate' current_user.obj.pk %}">
+                        <span class="{% fa_class 'check' %}"></span>
+                        {% trans 'Activate' %}
+                    </a>
+                </li>
+                {% endif %}
+
+                <li>
+                    <a href="{% url 'core:user:delete' current_user.obj.pk %}">
+                        <span class="{% fa_class 'trash' %}"></span>
+                        {% trans 'Delete' %}
+                    </a>
+                </li>
+            </ul>
+        </div>
+        {% endif %}
     </td>
     {% endif %}
 </tr>


### PR DESCRIPTION
#### What does this PR do?
Change colour for user deactivation.

#### Description of Task to be completed?
Change existing message colour or CSS for user deactivation to red `danger`.

#### How should this be manually tested?
Create a user with the role `trainer` and another, `gym administrator` (gym manager).
Log in as the manager and deactivate or delete the trainer.

#### Any background context you want to provide?
Previously, the colour was green `success`.

#### What are the relevant pivotal tracker stories?
[#157731581](https://www.pivotaltracker.com/story/show/157731581)