### PR TITLE
#157731570 Reset cache on muscle deletion

### DIFF
--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -19,6 +19,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin, LoginRequiredMix
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
+from django.core.cache import cache
 
 from django.views.generic import (
     ListView,
@@ -42,10 +43,14 @@ class MuscleListView(ListView):
     '''
     Overview of all muscles and their exercises
     '''
-    model = Muscle
-    queryset = Muscle.objects.all().order_by('-is_front', 'name'),
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
+
+    def get_queryset(self):
+        '''Get the new set of muscles after cache has been reset.
+        '''
+        queryset = Muscle.objects.all().order_by('-is_front', 'name'),
+        return queryset
 
     def get_context_data(self, **kwargs):
         '''
@@ -57,7 +62,7 @@ class MuscleListView(ListView):
         return context
 
 
-class MuscleAdminListView(LoginRequiredMixin, PermissionRequiredMixin, MuscleListView):
+class MuscleAdminListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     '''
     Overview of all muscles, for administration purposes
     '''
@@ -117,4 +122,5 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context = super(MuscleDeleteView, self).get_context_data(**kwargs)
         context['title'] = _(u'Delete {0}?').format(self.object.name)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
+        cache.clear()
         return context


### PR DESCRIPTION
#### What does this PR do?
Reset the cache when a muscle is deleted

#### Description of Task to be completed?
When one muscle or more are deleted, the cache is reset so that that muscle is not displayed in any other view where it was being displayed.

#### How should this be manually tested?
After logging on, navigate to the `muscles` page and delete a muscle(s). After navigate to any other page such as `muscle overview` page, here you will notice that the deleted muscle(s) will not be displayed anymore.

#### Any background context you want to provide?
Prior to this, when a muscle(s) was deleted from the `muscles` page, this deletion would not be reflected on the other pages where that muscle(s) was appearing.

#### What are the relevant pivotal tracker stories?
[#157731570](https://www.pivotaltracker.com/story/show/157731570)

[Delivers #157731570]