### PR TITLE
#157731575 Migrate to Zanata

### DIFF
--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -143,9 +143,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                                    <a href="https://translate.zanata.org/iteration/view/wg-millennium-falcon/v1">
                                         <span class="fa fa-external-link" aria-hidden="true"></span>
-                                        {% trans "Translate with Transifex" %}
+                                        {% trans "Translate with Zanata" %}
                                     </a>
                                 </li>
                             </ul>

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -126,7 +126,7 @@
                         {% endfor %}
                         <li class="divider"></li>
                         <li>
-                            <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                            <a href="https://translate.zanata.org/iteration/view/wg-millennium-falcon/v1">
                                 <span class="{% fa_class 'plus' %}"></span>
                                 {% trans "Translate" %}
                             </a>

--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -96,7 +96,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.transifex.com/rge/wger-workout-manager/" title="{% trans 'Translate' %}">
+                        <a href="https://translate.zanata.org/iteration/view/wg-millennium-falcon/v1" title="{% trans 'Translate' %}">
                             <span class="{% fa_class 'globe' %}"></span>
                         </a>
                     </li>

--- a/wger/locale/bg/LC_MESSAGES/django.po
+++ b/wger/locale/bg/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/rge/wger-workout-manager/language/bg/)\n"
+"Language-Team: Bulgarian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/bg/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1245,8 +1245,8 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Преведи с Transifex"
+msgid "Translate with Zanata"
+msgstr "Преведи с Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3791,9 +3791,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Искате ли да използвате wger на собствения си език? \nМислите ли, че сегашният превод може да се подобри? \nПреводите лесно се управляват и редактират онлайн. Ако се интересувате, \nотидете на сайтът transifex и поискайте достъп."
+msgstr "Искате ли да използвате wger на собствения си език? \nМислите ли, че сегашният превод може да се подобри? \nПреводите лесно се управляват и редактират онлайн. Ако се интересувате, \nотидете на сайтът zanata и поискайте достъп."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/cs/LC_MESSAGES/django.po
+++ b/wger/locale/cs/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Czech (http://www.transifex.com/rge/wger-workout-manager/language/cs/)\n"
+"Language-Team: Czech (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1244,8 +1244,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Přeložit s Transifex"
+msgid "Translate with Zanata"
+msgstr "Přeložit s Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3791,9 +3791,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Chcete používat wger v rodném jazyce?\nMyslíte si, že aktuální překlad by se měl zlepšit?\nPřeklady jdou snadno spravovat a upravovat online, pokud máte zájem,\njděte na stránku transifex a požádejte o přístup a my vám jej nastavíme."
+msgstr "Chcete používat wger v rodném jazyce?\nMyslíte si, že aktuální překlad by se měl zlepšit?\nPřeklady jdou snadno spravovat a upravovat online, pokud máte zájem,\njděte na stránku zanata a požádejte o přístup a my vám jej nastavíme."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/da/LC_MESSAGES/django.po
+++ b/wger/locale/da/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Danish (http://www.transifex.com/rge/wger-workout-manager/language/da/)\n"
+"Language-Team: Danish (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1242,7 +1242,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3788,7 +3788,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/de/LC_MESSAGES/django.po
+++ b/wger/locale/de/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:43+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: German (http://www.transifex.com/rge/wger-workout-manager/language/de/)\n"
+"Language-Team: German (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,8 +1243,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Mit Transifex übersetzen"
+msgid "Translate with Zanata"
+msgstr "Mit Zanata übersetzen"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3789,9 +3789,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Willst du wger in deiner Muttersprache benutzen? Denkst du dass die\naktuelle Übersetzung verbessert werden könnte? Die Übersetzungen können\nkomfortabel online verwaltet und editiert werden. Wenn du interessiert\nbist, gehe zur transifex Seite, trete in das Team ein und wir werden\nalle nötige aufsetzen."
+msgstr "Willst du wger in deiner Muttersprache benutzen? Denkst du dass die\naktuelle Übersetzung verbessert werden könnte? Die Übersetzungen können\nkomfortabel online verwaltet und editiert werden. Wenn du interessiert\nbist, gehe zur zanata Seite, trete in das Team ein und wir werden\nalle nötige aufsetzen."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/el/LC_MESSAGES/django.po
+++ b/wger/locale/el/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Greek (http://www.transifex.com/rge/wger-workout-manager/language/el/)\n"
+"Language-Team: Greek (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,8 +1243,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Μεταφράστε με το Transifex"
+msgid "Translate with Zanata"
+msgstr "Μεταφράστε με το Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3789,9 +3789,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Θέλετε να χρησιμοποιήσετε το wger στην γλώσσα σας;\nΝομίζετε ότι η τρέχουσα μετάφραση μπορεί να βελτιωθεί;\nΟι μεταφράσεις μπορούν να διαχειριστούν εύκολα και να επεξεργαστούν online. Αν ενδιαφέρεστε, επισκεφτείτε την σελίδα της transifex, αιτηθείτε πρόσβαση και τα υπόλοιπα θα τα ετοιμάσουμε εμείς."
+msgstr "Θέλετε να χρησιμοποιήσετε το wger στην γλώσσα σας;\nΝομίζετε ότι η τρέχουσα μετάφραση μπορεί να βελτιωθεί;\nΟι μεταφράσεις μπορούν να διαχειριστούν εύκολα και να επεξεργαστούν online. Αν ενδιαφέρεστε, επισκεφτείτε την σελίδα της zanata, αιτηθείτε πρόσβαση και τα υπόλοιπα θα τα ετοιμάσουμε εμείς."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/en/LC_MESSAGES/django.po
+++ b/wger/locale/en/LC_MESSAGES/django.po
@@ -1247,7 +1247,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3815,7 +3815,7 @@ msgid ""
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are "
 "interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/es/LC_MESSAGES/django.po
+++ b/wger/locale/es/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:54+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Spanish (http://www.transifex.com/rge/wger-workout-manager/language/es/)\n"
+"Language-Team: Spanish (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1245,8 +1245,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Traducir con Transifex"
+msgid "Translate with Zanata"
+msgstr "Traducir con Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3791,9 +3791,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "¿Quieres usar wger en tu idioma? ¿Crees que la traducción actual puede ser mejorada?\nLas traducciones se hacen confortablemente online, si tienes interés, ve a la página de transifex,\npide accesso y te pondremos todo lo que necesites."
+msgstr "¿Quieres usar wger en tu idioma? ¿Crees que la traducción actual puede ser mejorada?\nLas traducciones se hacen confortablemente online, si tienes interés, ve a la página de zanata,\npide accesso y te pondremos todo lo que necesites."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/fi/LC_MESSAGES/django.po
+++ b/wger/locale/fi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Finnish (http://www.transifex.com/rge/wger-workout-manager/language/fi/)\n"
+"Language-Team: Finnish (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1242,7 +1242,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3788,7 +3788,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/fr/LC_MESSAGES/django.po
+++ b/wger/locale/fr/LC_MESSAGES/django.po
@@ -18,7 +18,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: French (http://www.transifex.com/rge/wger-workout-manager/language/fr/)\n"
+"Language-Team: French (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1249,8 +1249,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Traduire avec Transifex"
+msgid "Translate with Zanata"
+msgstr "Traduire avec Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3795,7 +3795,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/hu/LC_MESSAGES/django.po
+++ b/wger/locale/hu/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Hungarian (http://www.transifex.com/rge/wger-workout-manager/language/hu/)\n"
+"Language-Team: Hungarian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,8 +1243,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Lefordítás Transifex segítségével"
+msgid "Translate with Zanata"
+msgstr "Lefordítás Zanata segítségével"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3789,7 +3789,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/it_IT/LC_MESSAGES/django.po
+++ b/wger/locale/it_IT/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Italian (Italy) (http://www.transifex.com/rge/wger-workout-manager/language/it_IT/)\n"
+"Language-Team: Italian (Italy) (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/it_IT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1244,7 +1244,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3790,7 +3790,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/ja/LC_MESSAGES/django.po
+++ b/wger/locale/ja/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Japanese (http://www.transifex.com/rge/wger-workout-manager/language/ja/)\n"
+"Language-Team: Japanese (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,7 +1243,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3788,7 +3788,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/nl/LC_MESSAGES/django.po
+++ b/wger/locale/nl/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Dutch (http://www.transifex.com/rge/wger-workout-manager/language/nl/)\n"
+"Language-Team: Dutch (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1245,8 +1245,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Vertaal met Transifex"
+msgid "Translate with Zanata"
+msgstr "Vertaal met Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3791,9 +3791,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Wil je wger gebruiken in je eigen taal?\nVind je dat de huidige vertaling kan worden verbeterd?\nDe vertalingen worden en eenvoudig online bewerkt en beheerd. Als je\ninteresse zou hebben, ga naar de transifex-site, vraag toegang aan wij\nzorgen voor de rest."
+msgstr "Wil je wger gebruiken in je eigen taal?\nVind je dat de huidige vertaling kan worden verbeterd?\nDe vertalingen worden en eenvoudig online bewerkt en beheerd. Als je\ninteresse zou hebben, ga naar de zanata-site, vraag toegang aan wij\nzorgen voor de rest."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/no/LC_MESSAGES/django.po
+++ b/wger/locale/no/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-07-08 05:55+0000\n"
 "Last-Translator: w00p <kjetil@stiligt.no>\n"
-"Language-Team: Norwegian (http://www.transifex.com/rge/wger-workout-manager/language/no/)\n"
+"Language-Team: Norwegian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/no/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,8 +1243,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Oversett med Transifex"
+msgid "Translate with Zanata"
+msgstr "Oversett med Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3789,9 +3789,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Ønsker du å bruke wger på ditt eget språk?\nTror du dagens oversettelse kan forbedres?\nOversettelsene er enkel å håndtere og redigeres på nettet, hvis du er interessert,\ngå til transifex området, be om tilgang og vi vil sette alt\nopp for deg."
+msgstr "Ønsker du å bruke wger på ditt eget språk?\nTror du dagens oversettelse kan forbedres?\nOversettelsene er enkel å håndtere og redigeres på nettet, hvis du er interessert,\ngå til zanata området, be om tilgang og vi vil sette alt\nopp for deg."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/os/LC_MESSAGES/django.po
+++ b/wger/locale/os/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Ossetic (http://www.transifex.com/rge/wger-workout-manager/language/os/)\n"
+"Language-Team: Ossetic (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/os/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1242,7 +1242,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3788,7 +3788,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wger/locale/pt_BR/LC_MESSAGES/django.po
@@ -16,7 +16,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/rge/wger-workout-manager/language/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1247,8 +1247,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Traduza com Transifex"
+msgid "Translate with Zanata"
+msgstr "Traduza com Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3793,9 +3793,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Você que usar o wger no seu próprio idioma?\nVocê acha que o estado atual da tradução pde ser melhorado?\nAs traduções são fácilmente gerenciados e editadas online, se você estiver interessado,\nvá até o site transifex, solicite acesso e nós iremos preparar tudo\npara você trabalhar."
+msgstr "Você que usar o wger no seu próprio idioma?\nVocê acha que o estado atual da tradução pde ser melhorado?\nAs traduções são fácilmente gerenciados e editadas online, se você estiver interessado,\nvá até o site zanata, solicite acesso e nós iremos preparar tudo\npara você trabalhar."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/ro/LC_MESSAGES/django.po
+++ b/wger/locale/ro/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Romanian (http://www.transifex.com/rge/wger-workout-manager/language/ro/)\n"
+"Language-Team: Romanian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,7 +1243,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3790,7 +3790,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/ru/LC_MESSAGES/django.po
+++ b/wger/locale/ru/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Russian (http://www.transifex.com/rge/wger-workout-manager/language/ru/)\n"
+"Language-Team: Russian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1245,8 +1245,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Перевести с помощью Transifex"
+msgid "Translate with Zanata"
+msgstr "Перевести с помощью Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3793,9 +3793,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Вы хотите пользоваться wger на своем родном языке?\nВы думаете, что текущий перевод может быть улучшен?\nПереводы легко управляются и редактируются онлайн, если вы заинтересованы, \nперейдите на сайт transifex, запросите доступ и мы все настроим."
+msgstr "Вы хотите пользоваться wger на своем родном языке?\nВы думаете, что текущий перевод может быть улучшен?\nПереводы легко управляются и редактируются онлайн, если вы заинтересованы, \nперейдите на сайт zanata, запросите доступ и мы все настроим."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/sv_SE/LC_MESSAGES/django.po
+++ b/wger/locale/sv_SE/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-18 23:08+0000\n"
 "Last-Translator: ywecur <emilio.alvarez96@gmail.com>\n"
-"Language-Team: Swedish (Sweden) (http://www.transifex.com/rge/wger-workout-manager/language/sv_SE/)\n"
+"Language-Team: Swedish (Sweden) (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/sv_SE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1244,8 +1244,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "Översätt med Transifex"
+msgid "Translate with Zanata"
+msgstr "Översätt med Zanata"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3790,9 +3790,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "Vill du använda wger på ditt eget språk?\nTror du att den aktuella översättningen kan förbättras?\nÖversättningar hanteras enkelt och redigeras online. Om du är intresserad, gå till webbplatsen transifex, begär åtkomst så kommer vi att inrätta allt. "
+msgstr "Vill du använda wger på ditt eget språk?\nTror du att den aktuella översättningen kan förbättras?\nÖversättningar hanteras enkelt och redigeras online. Om du är intresserad, gå till webbplatsen zanata, begär åtkomst så kommer vi att inrätta allt. "
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/tr/LC_MESSAGES/django.po
+++ b/wger/locale/tr/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Turkish (http://www.transifex.com/rge/wger-workout-manager/language/tr/)\n"
+"Language-Team: Turkish (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1241,7 +1241,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3787,7 +3787,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/uk/LC_MESSAGES/django.po
+++ b/wger/locale/uk/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Ukrainian (http://www.transifex.com/rge/wger-workout-manager/language/uk/)\n"
+"Language-Team: Ukrainian (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1245,7 +1245,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3792,7 +3792,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/locale/zh_CN/LC_MESSAGES/django.po
+++ b/wger/locale/zh_CN/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-27 08:29+0000\n"
 "Last-Translator: Armstrong Yan <yanqiangsdu@gmail.com>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/rge/wger-workout-manager/language/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1243,8 +1243,8 @@ msgid "Github"
 msgstr "Github"
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
-msgstr "在Transifex上翻译"
+msgid "Translate with Zanata"
+msgstr "在Zanata上翻译"
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
 #: core/templates/template_features.html:91
@@ -3788,9 +3788,9 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
-msgstr "你想通过母语来使用wger吗?\n你认为现在wger的翻译有待提高吗?\n翻译过程是很容易在线管理和编辑的,如果你感兴趣,请访问transifex网站,\n发出翻译请求,然后我们会搞定一切."
+msgstr "你想通过母语来使用wger吗?\n你认为现在wger的翻译有待提高吗?\n翻译过程是很容易在线管理和编辑的,如果你感兴趣,请访问zanata网站,\n发出翻译请求,然后我们会搞定一切."
 
 #: software/templates/contribute.html:88
 msgid "Code"

--- a/wger/locale/zh_TW/LC_MESSAGES/django.po
+++ b/wger/locale/zh_TW/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2016-02-14 10:32+0100\n"
 "PO-Revision-Date: 2016-02-14 09:34+0000\n"
 "Last-Translator: rge <roland@geider.net>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/rge/wger-workout-manager/language/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://translate.zanata.org/project/view/wg-millennium-falcon/v1/languages/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1242,7 +1242,7 @@ msgid "Github"
 msgstr ""
 
 #: core/templates/navigation.html:134 software/templates/contribute.html:82
-msgid "Translate with Transifex"
+msgid "Translate with Zanata"
 msgstr ""
 
 #: core/templates/navigation.html:149 core/templates/template.html:201
@@ -3787,7 +3787,7 @@ msgid ""
 "Do you want to use wger in your own language?\n"
 "Do you think the current translation could be improved?\n"
 "The translations are easily managed and edited online, if you are interested,\n"
-"go to the transifex site, request access and we will set everything\n"
+"go to the zanata site, request access and we will set everything\n"
 "up. "
 msgstr ""
 

--- a/wger/software/templates/contribute.html
+++ b/wger/software/templates/contribute.html
@@ -75,11 +75,11 @@ is too short or some other detail is missing or could be improved, tell!{% endbl
         <p>{% blocktrans %}Do you want to use wger in your own language?
 Do you think the current translation could be improved?
 The translations are easily managed and edited online, if you are interested,
-go to the transifex site, request access and we will set everything
+go to the zanata site, request access and we will set everything
 up. {% endblocktrans %}</p>
 
         <a class="btn btn-default"
-           href="https://www.transifex.com/rge/wger-workout-manager/">{% trans "Translate with Transifex" %} »</a>
+           href="https://translate.zanata.org/iteration/view/wg-millennium-falcon/v1">{% trans "Translate with Zanata" %} »</a>
     </div>
 </div>
 

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+  <url>https://translate.zanata.org/</url>
+  <project>wg-millennium-falcon</project>
+  <project-version>v1</project-version>
+  <project-type>gettext</project-type>
+
+</config>


### PR DESCRIPTION
#### What does this PR do?
Migrate from Transifex to open-source Zanata

#### Description of Task to be completed?
Change from translation platform [Transifex](https://www.transifex.com/) to open-source [Zanata](https://translate.zanata.org/).

#### How should this be manually tested?
Visit the translation project [wg-millennium-falcon](https://translate.zanata.org/iteration/view/wg-millennium-falcon/v1/).
Translate to a choice language based off the `django.pot` file template provided.
Download the translated `django.po` file and save it in the language folder of preference (see `./wger/locale/<language-code>/LC_MESSAGES/django.po`.

#### Any background context you want to provide?
Since Wger is open-source, there was need to move to an open-source translation service. Transifex is priced (https://www.transifex.com/pricing/) whereas Zanata is free and open-source.

#### What are the relevant pivotal tracker stories?
[#157731575](https://www.pivotaltracker.com/story/show/157731575)