### PR TITLE
#157731572 Relation between workout log and session

### DIFF
--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -720,6 +720,15 @@ class WorkoutLog(models.Model):
 
     date = Html5DateField(verbose_name=_('Date'))
 
+    '''
+        The session the log belongs to
+    '''
+    session = models.ForeignKey('WorkoutSession',
+                                null=True,
+                                blank=True,
+                                to_field='id'
+                                )
+
     # Metaclass to set some other properties
     class Meta:
         ordering = ["date", "reps"]

--- a/wger/manager/tests/test_weight_log.py
+++ b/wger/manager/tests/test_weight_log.py
@@ -160,7 +160,7 @@ class WeightLogOverviewAddTestCase(WorkoutManagerTestCase):
     Tests the weight log functionality
     '''
 
-    def add_weight_log(self, fail=True):
+    def add_weight_log(self, fail=True, rel=False):
         '''
         Helper function to test adding weight log entries
         '''
@@ -211,12 +211,22 @@ class WeightLogOverviewAddTestCase(WorkoutManagerTestCase):
             self.assertEqual(response.status_code, 302)
             self.assertGreater(count_after, count_before)
 
+        if fail is False and rel is True:
+            self.assertTrue(isinstance(WorkoutLog.objects.all()[0].session.id, int))
+
     def test_add_weight_log_anonymous(self):
         '''
         Tests adding weight log entries as an anonymous user
         '''
 
         self.add_weight_log(fail=True)
+
+    def test_add_weight_log_relation(self):
+        '''
+        Tests workoutlog and workoutsession table relationships
+        '''
+        self.user_login('admin')
+        self.add_weight_log(fail=False, rel=True)
 
     def test_add_weight_log_owner(self):
         '''

--- a/wger/manager/views/log.py
+++ b/wger/manager/views/log.py
@@ -180,6 +180,7 @@ def add(request, pk):
                     instance.weight = 0
                 instance.user = request.user
                 instance.workout = day.training
+                instance.session = WorkoutSession.objects.get(user=request.user, date=log_date)
                 instance.date = log_date
                 instance.save()
 


### PR DESCRIPTION
**What does this PR do?**

Creates a relationship between the manager_workoutlog and manager_workout_session tables

**Description of the task to be completed**

When querying the manager_workout_session table we should now be able to get all the related entries in the manager_workoutlog table. 

Here is a screenshot of related entries in the manage_workout_session table shown using pgAdmin for mac. Notice the last column session_id that shows the corresponding session id value from the manage_workout_session table.

<img width="1382" alt="screen shot 2018-06-14 at 13 36 33" src="https://user-images.githubusercontent.com/17172747/41407425-0aa73654-6fd8-11e8-8778-eaed000e069d.png">


**How should this be manually tested?**

After adding a new log through the Workouts -> Calendar menu option, the changes should be reflected in the manager_workoutlog table when viewed through a tool such as pgAdmin.

**Any background context you want to provide** 

There was no relationship between the manager_workoutlog and manager_workout_session tables.

**What are the relevant pivotal tracker stories?**

[#157731572](https://www.pivotaltracker.com/story/show/157731572)