### PR TITLE
#157731565 Cache nutritional values for plan 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ wger/core/static/bower_components
 node_modules
 
 venv-django/
+package-lock.json
+.DS_Store

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -109,50 +111,53 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        nutritional_representation = cache.get(cache_mapper.get_nutrition_cache_by_key(self.pk))
+        if not nutritional_representation:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
-
-        return result
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            nutritional_representation = result
+            cache.set(cache_mapper.get_nutrition_cache_by_key(self.pk), nutritional_representation)
+        return nutritional_representation
 
     def get_closest_weight_entry(self):
         '''
@@ -679,3 +684,20 @@ class MealItem(models.Model):
             nutritional_info[i] = Decimal(nutritional_info[i]).quantize(TWOPLACES)
 
         return nutritional_info
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=MealItem)
+def reset_nutritional_values_canonical_form(sender, **kwargs):
+    '''
+    Reset the nutrition values canonical form in cache
+    '''
+    sender_instance = kwargs["instance"]
+    if isinstance(sender_instance, (Meal, MealItem)):
+        cache.delete(cache_mapper.get_nutrition_cache_by_key(sender_instance.get_owner_object().id))
+    elif isinstance(sender_instance, NutritionPlan):
+        cache.delete(cache_mapper.get_nutrition_cache_by_key(sender_instance.id))

--- a/wger/nutrition/tests/test_nutritional_cache.py
+++ b/wger/nutrition/tests/test_nutritional_cache.py
@@ -1,0 +1,87 @@
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+from wger.core.models import Language
+
+
+class NutritionaCacheTestCase(WorkoutManagerTestCase):
+
+    def create_nutrition_plan(self):
+        '''
+        Create a nutrition plan and set dummy attributes that are required
+        Create meal and set dummy attributes that are required
+        Create meal item and set dummy attributes that are required
+        '''
+        nutrition_plan = NutritionPlan()
+        nutrition_plan.user = User.objects.create_user(username='example_user_1')
+        nutrition_plan.language = Language.objects.get(short_name="en")
+        nutrition_plan.save()
+        meal = Meal()
+        meal.plan = nutrition_plan
+        meal.order = 1
+        meal.save()
+        meal_item = MealItem()
+        meal_item.id = 1
+        meal_item.meal = meal
+        meal_item.amount = 1
+        meal_item.ingredient_id = 1
+        meal_item.order = 1
+        test_objects = [nutrition_plan, meal, meal_item]
+        return test_objects
+
+    def test_cache_setting(self):
+        '''
+        Test that a cache is set once the nutritional instance is created
+        '''
+        nutrition_object = self.create_nutrition_plan()[0]
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+
+    def test_nutrition_save_and_delete(self):
+        '''
+        Test that cache is deleted when a nutrition is created or deleted.
+        '''
+        nutrition_object = self.create_nutrition_plan()[0]
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+        nutrition_object.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+        nutrition_object.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutrition_object)))
+
+    def test_meal_save_delete(self):
+        '''
+        Test that the cache is deleted once a meal undergoes a save or delete operation
+        '''
+        test_object_list = self.create_nutrition_plan()
+        nutritional_object = test_object_list[0]
+        meal = test_object_list[1]
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object)))
+        meal.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object.pk)))
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object)))
+        meal.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object)))
+
+    def test_meal_item_save_delete(self):
+        '''
+        Test that the cache is deleted once a meal undergoes a save or delete operation
+        '''
+        test_object_list = self.create_nutrition_plan()
+        nutritional_object = test_object_list[0]
+        meal_item = test_object_list[2]
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object)))
+        meal_item.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object.pk)))
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutrition_cache_by_key(nutritional_object)))
+        meal_item.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutrition_cache_by_key(meal_item)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITION_CACHE_KEY = 'nutrition-cache-log-{0}'
 
     def get_pk(self, param):
         '''
@@ -114,6 +115,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutrition_cache_by_key(self, params):
+        '''
+        get nutritional info values canonical representation  using primary key.
+        '''
+        return self.NUTRITION_CACHE_KEY.format(self.get_pk(params))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
### What does this PR do?
This pull request depicts the changes made to fullfill the story for caching nutrition values for a nutrition plan 

### Description of task to be completed?
The task was to change the way in which calculated nutritional information for a particular nutritional plan was being rendered. The task was to cache data for nutritional information for each nutrition plan. The task further required that the cached data would be deleted in instances where the Meal or Meal Item, relevant to calculating the nutritional information, was added, edited or deleted. The task also required that when a Nutrition Plan was added or deleted that the cached data would be deleted appropriately. The deletion would later lead to the cache being set with data that was up to date.

### How should this be manually tested?
To run tests for this feature run the command python manage.py test 
`wger.nutrition.tests.test_nutrition_cache`
You can also run the command 
`python manage.py test` to run all the tests for the application

### What are the relevant pivotal tracker stories?
[#157731565](https://www.pivotaltracker.com/story/show/157731565)