### PR TITLE
#157731580 Add support for macrocycle, mesocycle and microcycle

### DIFF
--- a/wger/core/fixtures/days_of_week.json
+++ b/wger/core/fixtures/days_of_week.json
@@ -3,49 +3,200 @@
         "pk": 1, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Monday"
+            "day_of_week": "Monday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 2, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Tuesday"
+            "day_of_week": "Tuesday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 3, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Wednesday"
+            "day_of_week": "Wednesday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 4, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Thursday"
+            "day_of_week": "Thursday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 5, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Friday"
+            "day_of_week": "Friday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 6, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Saturday"
+            "day_of_week": "Saturday",
+            "workout_plan": "day"
         }
     }, 
     {
         "pk": 7, 
         "model": "core.daysofweek", 
         "fields": {
-            "day_of_week": "Sunday"
+            "day_of_week": "Sunday",
+            "workout_plan": "day"
+        }
+    },
+    {
+        "pk": 8, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 1",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 9, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 2",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 10, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 3",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 11, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 4",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 12, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 5",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 13, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "Week 6",
+            "workout_plan": "week"
+        }
+    },
+    {
+        "pk": 14, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "January",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 15, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "February",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 16, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "March",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 17, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "April",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 18, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "May",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 17, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "June",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 18, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "July",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 19, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "August",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 20, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "September",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 21, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "October",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 22, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "November",
+            "workout_plan": "Month"
+        }
+    },
+    {
+        "pk": 23, 
+        "model": "core.daysofweek", 
+        "fields": {
+            "day_of_week": "December",
+            "workout_plan": "Month"
         }
     }
 ]

--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -524,6 +524,7 @@ class DaysOfWeek(models.Model):
 
     day_of_week = models.CharField(max_length=9,
                                    verbose_name=_('Day of the week'))
+    workout_plan = models.CharField(max_length=5, null=True)
 
     class Meta:
         '''

--- a/wger/core/templates/tags/render_day.html
+++ b/wger/core/templates/tags/render_day.html
@@ -123,7 +123,13 @@ $(document).ready(function() {
             <td colspan="2">
                     <a href="{% url 'manager:set:add' day.obj.id %}"
                        class="wger-modal-dialog btn btn-default btn-block wger-modal-dialog">
-                       {% trans "No exercises selected for this day." %}
+                        {% if "Microcycle" in day.obj.training.cycle_type %}
+                            {% trans "No exercises selected for this day." %}
+                        {% elif "Mesocycle" in day.obj.training.cycle_type %}
+                            {% trans "No exercises selected for this week." %}
+                        {% elif "Macrocycle" in day.obj.training.cycle_type %}
+                            {% trans "No exercises selected for this month." %}
+                        {% endif %}
                        {% trans "Add one now." %}
                     </a>
             </td>
@@ -134,7 +140,15 @@ $(document).ready(function() {
         <tr>
             <td colspan="2">
                 <a href="{% url 'manager:set:add' day.obj.id %}"
-                   class="wger-modal-dialog">{% trans "Add exercises to this workout day" %}</a>
+                   class="wger-modal-dialog">
+                   {% if 'Microcycle' in day.obj.training.cycle_type %}
+                        {% trans "Add exercises to this workout day" %}
+                    {% elif 'Mesocycle' in day.obj.training.cycle_type %}
+                        {% trans "Add exercises to this workout week" %}
+                    {% elif 'Macrocycle' in day.obj.training.cycle_type %}
+                        {% trans "Add exercises to this workout month" %}
+                    {% endif %}
+                </a>
             </td>
         </tr>
         {% endif %}

--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -53,6 +53,11 @@ class Workout(models.Model):
     '''
     Model for a training schedule
     '''
+    CYCLE_OPTIONS = [
+        ('Microcycle', 'Microcycle - one week plan'),
+        ('Mesocycle', 'Mesocycle - Two to six weeks plan'),
+        ('Macrocycle', 'Macrocycle - one year plan')
+    ]
 
     class Meta:
         '''
@@ -67,6 +72,7 @@ class Workout(models.Model):
                                help_text=_("A short description or goal of the workout. For "
                                            "example 'Focus on back' or 'Week 1 of program xy'."))
     user = models.ForeignKey(User, verbose_name=_('User'))
+    cycle_type = models.CharField(max_length=10, choices=CYCLE_OPTIONS, default='')
 
     def get_absolute_url(self):
         '''

--- a/wger/manager/templates/workout/view.html
+++ b/wger/manager/templates/workout/view.html
@@ -58,25 +58,54 @@ $(document).ready(function() {
 </p>
 {% endif %}
 
+{% if workout.cycle_type %}
+<p>
+   <strong>{% trans "Plan" %}:</strong> {{workout.cycle_type}}
+</p>
+{% endif %}
+
 {% for day in workout.canonical_representation.day_list %}
     <div id="div-day-{{ day.obj.id }}">
         {% render_day day.obj is_owner %}
     </div>
 {% empty %}
     {% if is_owner %}
-        <p>
-            <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
-            {% trans "No days for this workout." %}
-            {% trans "Add training day" %}
-            </a>
-        </p>
+        {% if not workout.cycle_type %}
+            <p>
+                <a href="{% url 'manager:workout:edit' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
+                {% trans "Set a cycle type and optionally a goal for this workout" %}
+                </a>
+            </p>
+        {% else %}
+            <p>
+                <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog btn btn-default btn-block">
+                    {% if "Microcycle" in workout.cycle_type  %}
+                        {% trans "No days for this workout." %}
+                        {% trans "Add training day" %}
+                    {% elif "Mesocycle" in workout.cycle_type  %}
+                        {% trans "No weeks for this workout." %}
+                        {% trans "Add training week" %}
+                    {% elif "Macrocycle" in workout.cycle_type  %}
+                        {% trans "No months for this workout." %}
+                        {% trans "Add training month" %}
+                    {% endif %}
+                </a>
+            </p>
+            {% endif %}
     {% endif %}
 {% endfor %}
 
 {% if is_owner %}
 <p>
-    <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog">{% trans "Add training day" %}</a>
-    |
+    <a href="{% url 'manager:day:add' workout.id %}" class="wger-modal-dialog">
+            {% if "Microcycle" in workout.cycle_type  %}
+                {% trans "Add training day" %}
+            {% elif "Mesocycle" in workout.cycle_type  %}
+                {% trans "Add training week" %}
+            {% elif "Macrocycle" in workout.cycle_type  %}
+                {% trans "Add training month" %}
+            {% endif %}
+        </a>
     <a id="exercise-comments-toggle" href="{% url 'core:user:preferences' %}">{% trans "Show/Hide exercise comments" %}</a>
 </p>
 {% endif %}

--- a/wger/manager/tests/test_workout.py
+++ b/wger/manager/tests/test_workout.py
@@ -145,7 +145,7 @@ class EditWorkoutTestCase(WorkoutManagerEditTestCase):
     pk = 3
     user_success = 'test'
     user_fail = 'admin'
-    data = {'comment': 'A new comment'}
+    data = {'comment': 'A new comment', 'cycle_type': 'Microcycle'}
 
 
 class WorkoutOverviewTestCase(WorkoutManagerTestCase):

--- a/wger/manager/views/day.py
+++ b/wger/manager/views/day.py
@@ -87,6 +87,16 @@ class DayEditView(DayView, UpdateView):
     # Send some additional data to the template
     def get_context_data(self, **kwargs):
         context = super(DayEditView, self).get_context_data(**kwargs)
+        workout = Day.objects.get(pk=self.kwargs['pk']).training
+        if 'Microcycle' in workout.cycle_type:
+            context['form'].fields['day'].label = 'Day'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(workout_plan='day')
+        elif 'Mesocycle' in workout.cycle_type:
+            context['form'].fields['day'].label = 'Week'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(workout_plan='week')
+        elif 'Macrocycle' in workout.cycle_type:
+            context['form'].fields['day'].label = 'Month'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(workout_plan='month')
         context['title'] = _(u'Edit {0}').format(self.object)
         return context
 
@@ -96,7 +106,6 @@ class DayCreateView(DayView, CreateView):
     Generic view to add a new exercise day
     '''
 
-    title = ugettext_lazy('Add workout day')
     owner_object = {'pk': 'workout_pk', 'class': Workout}
 
     def form_valid(self, form):
@@ -108,7 +117,40 @@ class DayCreateView(DayView, CreateView):
 
     # Send some additional data to the template
     def get_context_data(self, **kwargs):
+        workout = Workout.objects.get(pk=self.kwargs['workout_pk'])
+        if 'Microcycle' in workout.cycle_type:
+            DayCreateView.title = _('Add workout day')
+        elif 'Mesocycle' in workout.cycle_type:
+            DayCreateView.title = _('Add workout week')
+        elif 'Macrocycle' in workout.cycle_type:
+            DayCreateView.title = _('Add workout month')
         context = super(DayCreateView, self).get_context_data(**kwargs)
+        cycle_type_selected = []
+        if workout.canonical_representation['day_list']:
+            for canonical_representation in workout.canonical_representation['day_list']:
+                for option in canonical_representation['days_of_week']['day_list']:
+                    cycle_type_selected.append(option.day_of_week)
+        if 'Microcycle' in workout.cycle_type:
+            context['form'].fields['day'].label = 'Day'
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this day (e.g. "Pull day") '
+                  ' what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                workout_plan='day').exclude(day_of_week__in=cycle_type_selected)
+        elif 'Mesocycle' in workout.cycle_type:
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this week (e.g. '
+                  '"Pull week") or what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].label = 'Week'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                workout_plan='week').exclude(day_of_week__in=cycle_type_selected)
+        elif 'Macrocycle' in workout.cycle_type:
+            context['form'].fields['description'].help_text = \
+                _('A description of what is done on this month (e.g. '
+                  '"Pull month") or what body parts are trained (e.g. "Arms and abs")')
+            context['form'].fields['day'].label = 'Month'
+            context['form'].fields['day'].queryset = DaysOfWeek.objects.filter(
+                workout_plan='Month').exclude(day_of_week__in=cycle_type_selected)
         context['form_action'] = reverse('manager:day:add',
                                          kwargs={'workout_pk': self.kwargs['workout_pk']})
         return context


### PR DESCRIPTION
### What does this PR do?
Adds support for macrocycle(Up to a year), mesocycle(2-6 weeks) and microcycle(1 week). 

### Description of Task to be completed?
Macro is an annual plan, meso is phase of training with a duration of between 2-6 weeks and micro is instead only a week.

This is needed for sports periodization ( powerlifting, weightlifting, strongman, ecc ) or at least to create fitness programs drafted on more than only one week.

### How should this be manually tested?
After logging, navigate to workouts and click on `Add workout`.

<img width="797" alt="screen shot 2018-06-18 at 05 29 54" src="https://user-images.githubusercontent.com/35847046/41515643-b60c39f8-72b8-11e8-9648-3a00a05ac3db.png">

The above screen will appear, click the button and you should see the following:

<img width="751" alt="screen shot 2018-06-18 at 05 31 36" src="https://user-images.githubusercontent.com/35847046/41515667-e4edbf8a-72b8-11e8-918c-100f384ddf62.png">

Select the cycle you want, put a description and save. Depending on which cycle you chose, one of the following should appear.

<img width="816" alt="screen shot 2018-06-18 at 05 34 14" src="https://user-images.githubusercontent.com/35847046/41515704-458dd3ca-72b9-11e8-99e5-1bc424e6501b.png">
<img width="805" alt="screen shot 2018-06-18 at 05 33 56" src="https://user-images.githubusercontent.com/35847046/41515706-45eabab8-72b9-11e8-8e12-37f390fbff1d.png">
<img width="799" alt="screen shot 2018-06-18 at 05 33 29" src="https://user-images.githubusercontent.com/35847046/41515707-46264e16-72b9-11e8-8a9e-66a5307c1219.png">

Then, you should see one of the following after clicking on the above:
<img width="621" alt="screen shot 2018-06-18 at 05 43 36" src="https://user-images.githubusercontent.com/35847046/41515957-c181127a-72ba-11e8-8ab6-6096260a05e1.png">
<img width="609" alt="screen shot 2018-06-18 at 05 43 12" src="https://user-images.githubusercontent.com/35847046/41515958-c1dbbff4-72ba-11e8-91c6-164f0d7e7ea5.png">
<img width="633" alt="screen shot 2018-06-18 at 07 38 14" src="https://user-images.githubusercontent.com/35847046/41518371-b9ae9f76-72ca-11e8-8ca9-583398d06104.png">

### Any background context you want to provide?
Prior to this, there was no support for Macrocycle, Mesocycle. There was only support for Microcycle.

### What are the relevant pivotal tracker stories?

[#157731580](https://www.pivotaltracker.com/story/show/157731580)