### PR TITLE
#157731573 Compare user weight data

### DIFF
--- a/wger/core/static/js/compare_weight.js
+++ b/wger/core/static/js/compare_weight.js
@@ -1,0 +1,79 @@
+/*
+ This file is part of wger Workout Manager.
+
+ wger Workout Manager is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ wger Workout Manager is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ */
+'use strict';
+
+$(document).ready(function () {
+  $('#compare').hide();
+  var url;
+  var username;
+  var nametext;
+  var chartParams;
+  var weightChart;
+  var checkboxes;
+  var data;
+
+  $('input[type=checkbox].checkbox').change(function () {
+    checkboxes = $('input[type=checkbox].checkbox:checked');
+    if (checkboxes.size() === 2) {
+      $('#compare').show();
+    } else {
+      $('#compare').hide();
+      $('#compare_weight_diagrams').empty();
+    }
+  });
+
+
+  $('#compare').click(function () {
+    var users = [];
+    $(checkboxes).each(function (index) {
+      username = $(this).attr('id');
+      nametext = $(this).attr('value');
+      url = '/weight/api/compare_weight_data/' + username;
+      users.push(nametext + ' (' + username + ')');
+
+      d3.json(url, function (json) {
+        weightChart = {};
+        chartParams = {
+          animate_on_load: true,
+          full_width: true,
+          top: 10,
+          left: 30,
+          right: 10,
+          show_secondary_x_label: true,
+          xax_count: 10,
+          target: '#weight_diagram_' + index,
+          x_accessor: 'date',
+          y_accessor: 'weight',
+          min_y_from_data: true,
+          colors: ['#3465a4'],
+          title: users[index]
+        };
+
+        if (json.length) {
+          $('#compare_weight_diagrams').append("<div id='weight_diagram_" + index + "'></div>");
+          data = MG.convert.date(json, 'date');
+          weightChart.data = data;
+
+          // Plot the data
+          chartParams.data = data;
+          MG.data_graphic(chartParams);
+        } else {
+          alert(users[index] + ' has no weight data');
+        }
+      });
+    });
+  });
+});

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -59,6 +59,7 @@ class ExerciseInfoSerializer(serializers.HyperlinkedModelSerializer):
     equipment = serializers.StringRelatedField(many=True)
     muscles_secondary = serializers.StringRelatedField(many=True)
     license = serializers.StringRelatedField()
+    license_author = serializers.StringRelatedField(read_only=True)
     exerciseimage_set = ExerciseImageSerializer(many=True, read_only=True)
 
     class Meta:

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -3,6 +3,7 @@
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
 <script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
 <script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
+<script src="{% static 'js/compare_weight.js' %}"></script>
 <script>
 $(document).ready( function () {
     /* Make table sortable */
@@ -66,15 +67,22 @@ $(document).ready( function () {
     }
 </style>
 
+<div class="pull-right">
+    <button id="compare" class="btn btn-success btn-sm" style="margin-top: -10px">Compare</button>
+</div>
+
+<div id="compare_weight_diagrams"></div>
+
 <div class="nav nav-tabs">
     <button class="tablinks" onclick="openUsers(event, 'Active')">Active</button>
     <button class="tablinks" onclick="openUsers(event, 'Inactive')">Inactive</button>
 </div>
-  
+
 <div id="Active" class="tabcontent">
     <table class="table table-hover" id="main_member_list">
         <thead>
         <tr>
+            <th></th>
             {% for key in user_table.keys %}
                 <th>{{ key }}</th>
             {% endfor %}
@@ -85,6 +93,9 @@ $(document).ready( function () {
         
         {% if current_user.obj.is_active %}
         <tr>
+            <td>
+                <input type="checkbox" class="checkbox" id="{{current_user.obj.username}}" value="{{current_user.obj.first_name}} {{current_user.obj.last_name}}">
+            </td>
             <td>
                 {{current_user.obj.pk}}
             </td>

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -105,7 +105,7 @@ INSTALLED_APPS = (
 BOWER_INSTALLED_APPS = (
     'bootstrap#3.3.5',
     'components-font-awesome#4.7.x',
-    'd3',
+    'd3#4.4.0',
     'DataTables',
     'devbridge-autocomplete#1.2.x',
     'jquery#2.1.x',

--- a/wger/weight/urls.py
+++ b/wger/weight/urls.py
@@ -50,4 +50,7 @@ urlpatterns = [
     url(r'^api/get_weight_data/$', # JS
         views.get_weight_data,
         name='weight-data'),
+    url(r'^api/compare_weight_data/(?P<username>[\w.@+-]+)$', # JS
+        views.compare_weight_data,
+        name='compare-weight-data'),
 ]


### PR DESCRIPTION
#### What does this PR do?
Compare user weight data

#### Description of Task to be completed?
Allow comparison by weight, of members training together
<img width="1440" alt="screen shot 2018-06-18 at 20 59 11" src="https://user-images.githubusercontent.com/7848682/41553603-ea96724c-733a-11e8-9d65-0244d451ccbf.png">

#### How should this be manually tested?
Select two users from the user list and click the compare button. Graphs of their weight data will display next to each other.

#### Any background context you want to provide?
Previously, there was no comparison of any sort.

#### What are the relevant pivotal tracker stories?
[#157731573](https://www.pivotaltracker.com/story/show/157731573)